### PR TITLE
AZERY  QWERTY default layout button

### DIFF
--- a/src/main/java/com/blamejared/controlling/client/gui/GuiNewControls.java
+++ b/src/main/java/com/blamejared/controlling/client/gui/GuiNewControls.java
@@ -12,8 +12,6 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.input.Keyboard;
 
-import com.blamejared.controlling.Controlling;
-
 import cpw.mods.fml.client.config.GuiCheckBox;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/blamejared/controlling/client/gui/GuiNewControls.java
+++ b/src/main/java/com/blamejared/controlling/client/gui/GuiNewControls.java
@@ -24,8 +24,6 @@ public class GuiNewControls extends GuiControls {
     private static final GameSettings.Options[] OPTIONS_ARR = new GameSettings.Options[] {
             GameSettings.Options.INVERT_MOUSE, GameSettings.Options.SENSITIVITY, GameSettings.Options.TOUCHSCREEN };
 
-    private static boolean isQwertyLayout = true;
-
     private final GuiScreen parentScreen;
     private final GameSettings options;
     private GuiButton buttonReset;
@@ -42,6 +40,7 @@ public class GuiNewControls extends GuiControls {
     private GuiCheckBox buttonCat;
     private GuiButton sortOrderButton;
     private boolean confirmingReset = false;
+    private boolean isQwertyLayout;
 
     private String name;
 
@@ -49,6 +48,7 @@ public class GuiNewControls extends GuiControls {
         super(screen, settings);
         this.parentScreen = screen;
         this.options = settings;
+        this.isQwertyLayout = !(this.options.keyBindForward.getKeyCode() == Keyboard.KEY_Z);
     }
 
     /**
@@ -454,7 +454,7 @@ public class GuiNewControls extends GuiControls {
      * AZERTY : Go Left -> Q Walk Forward -> Z Drop Item -> A
      */
     private void bindKeysToDefaultKeyboardLayout() {
-        if (isQwertyLayout) {
+        if (this.isQwertyLayout) {
             this.options.keyBindLeft.setKeyCode(this.options.keyBindLeft.getKeyCodeDefault());
             this.options.keyBindForward.setKeyCode(this.options.keyBindForward.getKeyCodeDefault());
             this.options.keyBindDrop.setKeyCode(this.options.keyBindDrop.getKeyCodeDefault());

--- a/src/main/java/com/blamejared/controlling/client/gui/GuiNewControls.java
+++ b/src/main/java/com/blamejared/controlling/client/gui/GuiNewControls.java
@@ -1,9 +1,7 @@
 package com.blamejared.controlling.client.gui;
 
-import java.awt.*;
 import java.io.IOException;
 import java.util.*;
-import java.util.List;
 import java.util.function.Predicate;
 
 import net.minecraft.client.Minecraft;
@@ -11,6 +9,8 @@ import net.minecraft.client.gui.*;
 import net.minecraft.client.settings.GameSettings;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.util.StatCollector;
+
+import org.lwjgl.input.Keyboard;
 
 import com.blamejared.controlling.Controlling;
 
@@ -23,6 +23,8 @@ public class GuiNewControls extends GuiControls {
 
     private static final GameSettings.Options[] OPTIONS_ARR = new GameSettings.Options[] {
             GameSettings.Options.INVERT_MOUSE, GameSettings.Options.SENSITIVITY, GameSettings.Options.TOUCHSCREEN };
+
+    private static boolean isQwertyLayout = true;
 
     private final GuiScreen parentScreen;
     private final GameSettings options;
@@ -77,6 +79,16 @@ public class GuiNewControls extends GuiControls {
             }
             ++i;
         }
+
+        this.buttonList.add(
+                new GuiButton(
+                        999,
+                        this.width / 2 - 155 + i % 2 * 160,
+                        18 + 24 * (i >> 1),
+                        150,
+                        20,
+                        StatCollector.translateToLocal("options.keyboardLayout")
+                                + (this.isQwertyLayout ? "QWERTY" : "AZERTY")));
 
         this.keyBindingList = new GuiNewKeyBindingList(this, this.mc);
 
@@ -278,6 +290,11 @@ public class GuiNewControls extends GuiControls {
         if (button.id < 100 && button instanceof GuiOptionButton) {
             this.options.setOptionValue(((GuiOptionButton) button).returnEnumOptions(), 1);
             button.displayString = this.options.getKeyBinding(GameSettings.Options.getEnumOptions(button.id));
+        } else if (button.id == 999) {
+            this.isQwertyLayout = !this.isQwertyLayout;
+            button.displayString = StatCollector.translateToLocal("options.keyboardLayout")
+                    + (this.isQwertyLayout ? "QWERTY" : "AZERTY");
+            bindKeysToDefaultKeyboardLayout();
         } else if (button.id == 1001) {
             mc.displayGuiScreen(this.parentScreen);
         } else if (button.id == 1002) {
@@ -427,4 +444,27 @@ public class GuiNewControls extends GuiControls {
             }
         }
     }
+
+    /**
+     * When the associated GuiButton is pressed, it will bind the vanilla minecraft keys to the default values for a
+     * QWERTY keyboard. When pressed again it will bind them to the default values for an AZERTY keyboard
+     * <p>
+     * QWERTY : Go Left -> A Walk Forward -> W Drop Item -> Q
+     * <p>
+     * AZERTY : Go Left -> Q Walk Forward -> Z Drop Item -> A
+     */
+    private void bindKeysToDefaultKeyboardLayout() {
+        if (isQwertyLayout) {
+            this.options.keyBindLeft.setKeyCode(this.options.keyBindLeft.getKeyCodeDefault());
+            this.options.keyBindForward.setKeyCode(this.options.keyBindForward.getKeyCodeDefault());
+            this.options.keyBindDrop.setKeyCode(this.options.keyBindDrop.getKeyCodeDefault());
+        } else {
+            this.options.keyBindLeft.setKeyCode(Keyboard.KEY_Q);
+            this.options.keyBindForward.setKeyCode(Keyboard.KEY_Z);
+            this.options.keyBindDrop.setKeyCode(Keyboard.KEY_A);
+        }
+        this.options.saveOptions();
+        KeyBinding.resetKeyBindingArrayAndHash();
+    }
+
 }

--- a/src/main/resources/assets/controlling/lang/en_US.lang
+++ b/src/main/resources/assets/controlling/lang/en_US.lang
@@ -11,3 +11,4 @@ options.sortAZ=A->Z
 options.sortZA=Z->A
 options.toggleFree=Toggle Free
 options.confirmReset=Click to confirm reset!
+options.keyboardLayout=Default Layout : 


### PR DESCRIPTION
Adds a button in the controls gui. When it is pressed, it will bind the vanilla minecraft keys to the default values for a QWERTY keyboard. When pressed again it will bind them to the default values for an AZERTY keyboard

![image](https://user-images.githubusercontent.com/57050655/216855063-206f4525-f23d-4a3c-a551-e25dd51ae3bf.png)
